### PR TITLE
Feature dev container for development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,67 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-docker-compose
+{
+    "name": "Zumito Framework Dev Container",
+
+    // Update the 'dockerComposeFile' list if you have more compose files or use different names.
+    // The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
+    "dockerComposeFile": ["../docker-compose.yml", "docker-compose.yml"],
+
+    // The 'service' property is the name of the service for the container that VS Code should
+    // use. Update this value and .devcontainer/docker-compose.yml to the real service name.
+    "service": "zdev",
+
+    // The optional 'workspaceFolder' property is the path VS Code should open by default when
+    // connected. This is typically a file mount in .devcontainer/docker-compose.yml
+    "workspaceFolder": "/zumito-framework",
+
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    // "features": {},
+
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+
+    // Uncomment the next line if you want start specific services in your Docker Compose config.
+    "runServices": [
+        // "zdb-mysql"
+        // "zdb-postgres"
+        // "zdb-mongo"
+        "zdb-couchdb"
+    ],
+
+    // Uncomment the next line if you want to keep your containers running after VS Code shuts down.
+    "shutdownAction": "stopCompose",
+
+    // Uncomment the next line to run commands after the container is created.
+    // "postCreateCommand": "cat /etc/os-release",
+
+    // Configure tool-specific properties.
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "[typescript]": {
+                    "editor.defaultFormatter": "esbenp.prettier-vscode",
+                    "editor.formatOnSave": true,
+                    "editor.codeActionsOnSave": {
+                        "source.fixAll": true,
+                        "source.organizeImports": true
+                    },
+                    "editor.insertSpaces": true,
+                    "editor.tabSize": 4
+                }
+            },
+            "extensions": [
+                "dbaeumer.vscode-eslint",
+                "esbenp.prettier-vscode",
+                "rvest.vs-code-prettier-eslint",
+                "ms-azuretools.vscode-docker",
+                "donjayamanne.githistory",
+                "waderyan.gitblame",
+                "eamodio.gitlens"
+            ]
+        }
+    },
+
+    // Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
+    "remoteUser": "node"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.9'
+services:
+  # Update this to the name of the service you want to work with in your docker-compose.yml file
+  zdev:
+    # Uncomment if you want to override the service's Dockerfile to one in the .devcontainer 
+    # folder. Note that the path of the Dockerfile and context is relative to the *primary* 
+    # docker-compose.yml file (the first in the devcontainer.json "dockerComposeFile"
+    # array). The sample below assumes your primary file is in the root of your project.
+    #
+    # build:
+    #   context: .
+    #   dockerfile: .devcontainer/Dockerfile
+
+    volumes:
+      # Update this to wherever you want VS Code to mount the folder of your project
+      - .:/zumito-framework:cached
+
+    # Uncomment the next four lines if you will use a ptrace-based debugger like C++, Go, and Rust.
+    # cap_add:
+    #   - SYS_PTRACE
+    # security_opt:
+    #   - seccomp:unconfined
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: /bin/sh -c "while sleep 1000; do :; done"

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+#MYSQL env variables. For more env variables, see https://hub.docker.com/_/mysql
+MYSQL_DATABASE=<DatabaseName>
+MYSQL_ROOT_PASSWORD=<RootPassword>
+
+#Postgres env variables. For more env variables, see https://hub.docker.com/_/postgres
+POSTGRES_DB=<DatabaseName>
+POSTGRES_PASSWORD=<RootPassword>
+
+#Mongo env variables. For more env variables, see https://hub.docker.com/_/mongo
+MONGO_INITDB_ROOT_USERNAME=<RootUsername>
+MONGO_INITDB_ROOT_PASSWORD=<RootPassword>
+MONGO_INITDB_DATABASE=<DatabaseName>
+
+#CouchDB env variables. For more env variables, see https://hub.docker.com/_/couchdb
+COUCHDB_USER=<RootUsername>
+COUCHDB_PASSWORD=<RootPassword>
+NODENAME=<DatabaseName>

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+#Base stage
+FROM node:18.16.0-slim AS base
+RUN apt update && \
+    npm i -g npm@latest
+
+WORKDIR /zumito-framework
+
+# Development stage
+FROM base AS dev
+RUN apt update && \
+    apt install -y git
+
+USER node
+CMD [ "bash" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,50 @@
+version: "3.9"
+services:
+  zdev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: dev
+    container_name: zdev
+
+  zdb-mysql:
+    image: mysql:8.0.33-debian
+    container_name: zdb-mysql
+    volumes:
+      - zdb-mysql:/var/lib/mysql
+    env_file: .env
+    profiles:
+      - mysql
+
+  zdb-postgres:
+    image: postgres:15.3-alpine3.18
+    container_name: zdb-postgres
+    volumes:
+      - zdb-postgres:/var/lib/postgresql/data
+    env_file: .env
+    profiles:
+      - postgres
+
+  zdb-mongo:
+    image: mongo:6.0.7
+    container_name: zdb-mongo
+    volumes:
+      - zdb-mongo:/data/db
+    env_file: .env
+    profiles:
+      - mongo
+
+  zdb-couchdb:
+    image: couchdb:3.3.2
+    container_name: zdb-couchdb
+    volumes:
+      - zdb-couchdb:/opt/couchdb/data
+    env_file: .env
+    profiles:
+      - couchdb
+
+volumes:
+  zdb-mysql:
+  zdb-postgres:
+  zdb-mongo:
+  zdb-couchdb:


### PR DESCRIPTION
Hi :wave: 

This pull request is for the feature discused in issue #30 . I add the necessary docker files and the devcontainer configuration to setup the development environment. As i mentioned in the issue, the requirements to use this features are:

* Have docker and docker compose installed on the host machine.
* Have installed DevContainers vscode extension.

With that requirements installed, you can open the project folder and:

* press `ctrl + shift + p` and search for the option `Dev Containers: Reopen in Container`.
* After that, the extension will build the image and pull all the required images to setup the devcontainer.
* Finally, the editor will be opened in the new container. If you open the integrated terminal, it'll be open inside the container

All the plugins that will be installed in the container are specified in the devcontainer.json file. All the things placed under `"customizations.vscode.extensions` are the extensions installed in the container. And the attributes in `customizations.vscode.settings` are the global settings for vscode inside the container.

Another important thing in the devcontainer.json is the `"runService"` attribute. It's an array of all the services that must be run with the devcontainer. Here we can specify any service that are present in the docker-compose file.

This pull request is not meant to be approved at first. I want you to try this feature and give me feadback about it. Also, all the extensions that are installed are base on what i see you are using. So feel free to add or request to add more extensions that you find usefull to have in the container. And if i must to change the readme file to add the posibility of use this feature for development.