### PR TITLE
feat: Add router system

### DIFF
--- a/src/ZumitoFramework.ts
+++ b/src/ZumitoFramework.ts
@@ -100,7 +100,7 @@ export class ZumitoFramework {
      * @see {@link TranslationManager}
      */
     translations: TranslationManager;
-    routes: any;
+    routes: Map<string, (req: Request, res: Response) => void>;
     
     /**
      * The database models loaded in the framework.
@@ -162,6 +162,7 @@ export class ZumitoFramework {
         this.events = new Map();
         this.translations = new TranslationManager();
         this.models = [];
+        this.routes = new Map();
         this.eventManager = new EventManager();
 
         if (settings.logLevel) {
@@ -188,12 +189,12 @@ export class ZumitoFramework {
     private async initialize() {
         await this.initializeDatabase();
         await this.initializeDiscordClient();
-        this.startApiServer();
 
         this.eventManager.addEventEmitter('discord', this.client);
         this.eventManager.addEventEmitter('framework', this.eventEmitter);
         
         await this.registerModules();
+        this.startApiServer();
         await this.refreshSlashCommands();
         if (this.settings.statusOptions) {
             this.statusManager = new StatusManager(this, this.settings.statusOptions);
@@ -254,6 +255,10 @@ export class ZumitoFramework {
         //Route Prefixes
         //this.app.use("/", indexRouter);
         //this.app.use("/api/", apiRouter);
+        console.log(this.routes.size);
+        this.routes.forEach((router, path) => {
+            this.app.use(path, router);
+        });
 
         // throw 404 if URL not found
         this.app.all('*', function (req, res) {

--- a/src/definitions/FrameworkRouter.ts
+++ b/src/definitions/FrameworkRouter.ts
@@ -1,0 +1,11 @@
+import { Request, Response } from 'express';
+
+export abstract class FrameworkRouter {
+    basePath: string = '';
+
+    constructor(basePath: string) {
+        this.basePath = basePath;
+    }
+
+    abstract getRoutes(): Map<string, (req: Request, res: Response) => void>;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import { TranslationManager } from './services/TranslationManager.js';
 import { ZumitoFramework } from './ZumitoFramework.js';
 import * as discord from 'discord.js';
 import { EventParameters } from './definitions/parameters/EventParameters.js';
+import { FrameworkRouter } from './definitions/FrameworkRouter.js';
 
 export {
     ZumitoFramework,
@@ -54,4 +55,5 @@ export {
     StatusManagerOptions,
     discord,
     EventParameters,
+    FrameworkRouter,
 };

--- a/src/services/ModuleManager.ts
+++ b/src/services/ModuleManager.ts
@@ -66,12 +66,8 @@ export class ModuleManager {
             this.framework.models.push(model);
         });
 
-        /*
-
         // Register module routes
-        this.routes = new Map([...this.routes, ...moduleInstance.getRoutes()]);
-
-        */
+        this.framework.routes = new Map([...this.framework.routes, ...module.getRoutes()] as any);
     }
 
     async instanceModule(module: any, rootPath: string, name?: string) {


### PR DESCRIPTION
### Summary:
This Pull Request aims to enhance the ZumitoFramework by introducing user routing functionality, empowering developers to publish endpoints on their bot via an express server. The primary addition is the creation of a new class called `FrameworkRouter`, dedicated to be extended by developers who want to create new routes

### Changes Introduced:
- **Creation of FrameworkRouter Class:** A new class, `FrameworkRouter`, has been added to the ZumitoFramework. This class is responsible for handling all routing-related tasks.
- **Route Definition Refactoring:** Routes are now defined using a Map type within the ZumitoFramework class, offering improved organization and accessibility.
- **Module Route Registration Updates:** The process of registering module routes has been modified to accommodate the new routing functionality.
- **Exporting FrameworkRouter:** The `FrameworkRouter` class is exported in the `index.ts` file for accessibility across the framework.
- **Introduction of FrameworkRouter Class:** The `FrameworkRouter` class includes a constructor for setting up a `basePath` and an abstract method `getRoutes()`, enhancing flexibility and customization.
- **Module Class Enhancements:** New methods, `registerRoutes()` and `getRoutes()`, have been added to the Module class for registering and retrieving routes, respectively.

### Objective:
These modifications are geared towards improving the route handling capabilities of the ZumitoFramework. By introducing user routing functionality and refining the routing process, this Pull Request seeks to enhance the framework's flexibility and usability, ultimately empowering developers to build more robust and efficient bots.

### Implementation
Here is an example of a route implementantion on a bot
src/modules/general/routes/Example.ts
```ts
import { FrameworkRouter } from "zumito-framework";

export class Example extends FrameworkRouter {
    getRoutes(): Map<string, (req: any, res: any) => void> {
        const routes = new Map();

        routes.set('/test', (req: any, res: any) => {
            res.send('test');
        });

        return routes;
    } 
}
```
