### PR TITLE
fix: bot rich presence not working

### DIFF
--- a/src/services/StatusManager.ts
+++ b/src/services/StatusManager.ts
@@ -26,12 +26,22 @@ export class StatusManager {
      * @private
      */
     private delegateEvents() {
-        this.framework.client.on("ready", () => {
-            this.setStatus();
+        if (this.framework.client.isReady()) {
+            this.initialize();
+        } else {
+            (this.framework.client as Client).on("ready", () => {
+                this.initialize();
+            });
+        }
+    }
+
+    initialize() {
+        this.setStatus();
+        if (this.options.updateInterval) {
             setInterval(() => {
                 this.setStatus();
             }, this.options.updateInterval);
-        });
+        }
     }
 
     /**


### PR DESCRIPTION
Whats not working: The bot doesn't show a status on discord.
What's the problem: Seems like in recent changes, execution ordes has changed and the Discord client is alredy initialized when the `ready` event listener is runned.
What's the solution: Checked if the client is alredy ready before listen the event.