### PR TITLE
Fix string method in error handler

### DIFF
--- a/src/services/handlers/ErrorHandler.ts
+++ b/src/services/handlers/ErrorHandler.ts
@@ -115,10 +115,11 @@ export class ErrorHandler {
             if (!codeFragment && functionName?.includes('.execute')) {
                 let columnEnd = -1;
                 if (lastStack) {
-                    if (lastStack.getFunctionName().contains('.')) {
-                        columnEnd = lastStack.getFunctionName().split('.').at(-1).length;
+                    const lastFunctionName = lastStack.getFunctionName();
+                    if (lastFunctionName.includes('.')) {
+                        columnEnd = lastFunctionName.split('.').at(-1).length;
                     } else {
-                        columnEnd = lastStack.getFunctionName().length;
+                        columnEnd = lastFunctionName.length;
                     }
                 }
                 codeFragment = {


### PR DESCRIPTION
## Summary
- use `includes` on function names when parsing error stack

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684bc0bd0a70832f920b043568dac264