### PR TITLE
Change default command type to any

### DIFF
--- a/src/definitions/commands/Command.ts
+++ b/src/definitions/commands/Command.ts
@@ -181,7 +181,7 @@ export abstract class Command {
      * @name type
      * @description The type of the command. This is used to determine how the command should be executed.
      * @type {CommandType}
-     * @default CommandType.prefix
+     * @default CommandType.any
      * @example
      * ```ts
      * export class PingCommand extends Command {
@@ -202,7 +202,7 @@ export abstract class Command {
      * ```
      * @see {@link CommandType}
      */
-    type: string = CommandType.prefix;
+    type: string = CommandType.any;
 
     parent?: string;
     binds?: CommandBinds;


### PR DESCRIPTION
## Summary
- set default command type to `CommandType.any`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684bc2d29d30832fb615059b957759e7