### PR TITLE
Add number option support

### DIFF
--- a/src/services/SlashCommandRefresher.ts
+++ b/src/services/SlashCommandRefresher.ts
@@ -59,6 +59,9 @@ export class SlashCommandRefresher {
                     case 'string':
                         method = 'addStringOption';
                         break;
+                    case 'number':
+                        method = 'addNumberOption';
+                        break;
                     case 'user':
                     case 'member':
                         method = 'addUserOption';

--- a/src/services/managers/CommandManager.ts
+++ b/src/services/managers/CommandManager.ts
@@ -165,6 +165,9 @@ export class CommandManager {
                             case 'string':
                                 method = 'addStringOption';
                                 break;
+                            case 'number':
+                                method = 'addNumberOption';
+                                break;
                             case 'user':
                             case 'member':
                                 method = 'addUserOption';


### PR DESCRIPTION
## Summary
- support numeric options in command refreshers

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bc63dbc18832f9ef7a50dd187dfa0