### PR TITLE
fix: improve invalid argument error

### DIFF
--- a/src/services/SlashCommandRefresher.ts
+++ b/src/services/SlashCommandRefresher.ts
@@ -74,7 +74,7 @@ export class SlashCommandRefresher {
                         break;
                     default:
                         throw new Error(
-                            'Invalid argument type ' + arg.type
+                            `Invalid argument type ${arg.type} in command ${command.name} for argument ${arg.name}`
                         );
                 }
                 slashCommand[method]((option) => {

--- a/src/services/managers/CommandManager.ts
+++ b/src/services/managers/CommandManager.ts
@@ -180,7 +180,7 @@ export class CommandManager {
                                 break;
                             default:
                                 throw new Error(
-                                    'Invalid argument type ' + arg.type
+                                    `Invalid argument type ${arg.type} in command ${command.name} for argument ${arg.name}`
                                 );
                         }
                         slashCommand[method]((option) => {


### PR DESCRIPTION
## Summary
- add detailed context to invalid argument type errors

## Testing
- `npm run lint` *(fails: ESLint couldn't find eslint.config or lint errors)*
- `npm test` *(fails: no tests specified)*


------
https://chatgpt.com/codex/tasks/task_e_684bcd149d7c832fa996bfaa2ae329be