### PR TITLE
Emit error events from handler

### DIFF
--- a/src/services/handlers/ErrorHandler.ts
+++ b/src/services/handlers/ErrorHandler.ts
@@ -57,6 +57,9 @@ export class ErrorHandler {
             console.line('');
         }
 
+        // Emit framework error event so external modules can listen and report
+        this.framework.eventEmitter.emit('error', error, options);
+
         this.printErrorStack(error);
 
         if (options.exit) process.exit(1);


### PR DESCRIPTION
## Summary
- emit a `framework` error event from `ErrorHandler`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684be2d6d7cc832f86680956a6db90cc