### PR TITLE
Add application emoji support to EmojiFallback service

### DIFF
--- a/src/services/EmojiFallback.ts
+++ b/src/services/EmojiFallback.ts
@@ -19,7 +19,12 @@ export class EmojiFallback {
             emojiId = this.translator.get(emojiId);
         }
         const emoji = this.client.emojis.cache.get(emojiId);
-        return emoji?.toString() || fallbackEmoji;
+        if (emoji) return emoji.toString();
+
+        const appEmoji = this.getApplicationEmoji(emojiId);
+        if (appEmoji) return appEmoji.toString();
+
+        return fallbackEmoji;
     }
 
     public getEmojiByName(
@@ -29,7 +34,12 @@ export class EmojiFallback {
         const emoji = this.client.emojis.cache.find(
             (emoji) => emoji.name === emojiName
         );
-        return emoji?.toString() || fallbackEmoji;
+        if (emoji) return emoji.toString();
+
+        const appEmoji = this.getApplicationEmojiByName(emojiName);
+        if (appEmoji) return appEmoji.toString();
+
+        return fallbackEmoji;
     }
 
     public getEmojiByIdentifier(
@@ -40,6 +50,23 @@ export class EmojiFallback {
             emojiId = this.translator.get(emojiId);
         }
         const emoji = this.client.emojis.cache.find((emoji) => emoji.id === emojiId);
-        return emoji?.toString() || fallbackEmoji;
+        if (emoji) return emoji.toString();
+
+        const appEmoji = this.getApplicationEmoji(emojiId);
+        if (appEmoji) return appEmoji.toString();
+
+        return fallbackEmoji;
+    }
+
+    public getApplicationEmoji(emojiId: string) {
+        if (!this.client.application) return undefined;
+        return this.client.application.emojis.cache.get(emojiId);
+    }
+
+    public getApplicationEmojiByName(emojiName: string) {
+        if (!this.client.application) return undefined;
+        return this.client.application.emojis.cache.find(
+            (emoji) => emoji.name === emojiName
+        );
     }
 }

--- a/src/services/EmojiFallback.ts
+++ b/src/services/EmojiFallback.ts
@@ -5,20 +5,25 @@ export class EmojiFallback {
 
     client: Client;
     translator: TranslationManager;
+    private applicationEmojisPromise: Promise<unknown> | null = null;
 
     constructor(client: Client, translator: TranslationManager) {
         this.client = client;
         this.translator = translator;
-        if (client.isReady()) {
-            client.application?.emojis?.fetch().catch(() => {});
-        } else {
-            client.once('ready', () => {
-                client.application?.emojis?.fetch().catch(() => {});
-            });
-        }
     }
 
-    public getEmoji(
+    private ensureApplicationEmojis(): Promise<unknown> {
+        if (!this.applicationEmojisPromise) {
+            if (this.client.application) {
+                this.applicationEmojisPromise = this.client.application.emojis.fetch().catch(() => {});
+            } else {
+                this.applicationEmojisPromise = Promise.resolve();
+            }
+        }
+        return this.applicationEmojisPromise;
+    }
+
+    public async getEmoji(
         emojiId: string,
         fallbackEmoji: any
     ) {
@@ -28,13 +33,13 @@ export class EmojiFallback {
         const emoji = this.client.emojis.cache.get(emojiId);
         if (emoji) return emoji.toString();
 
-        const appEmoji = this.getApplicationEmoji(emojiId);
+        const appEmoji = await this.getApplicationEmoji(emojiId);
         if (appEmoji) return appEmoji.toString();
 
         return fallbackEmoji;
     }
 
-    public getEmojiByName(
+    public async getEmojiByName(
         emojiName: string,
         fallbackEmoji: any
     ) {
@@ -43,13 +48,13 @@ export class EmojiFallback {
         );
         if (emoji) return emoji.toString();
 
-        const appEmoji = this.getApplicationEmojiByName(emojiName);
+        const appEmoji = await this.getApplicationEmojiByName(emojiName);
         if (appEmoji) return appEmoji.toString();
 
         return fallbackEmoji;
     }
 
-    public getEmojiByIdentifier(
+    public async getEmojiByIdentifier(
         emojiId: string,
         fallbackEmoji: any
     ) {
@@ -59,19 +64,21 @@ export class EmojiFallback {
         const emoji = this.client.emojis.cache.find((emoji) => emoji.id === emojiId);
         if (emoji) return emoji.toString();
 
-        const appEmoji = this.getApplicationEmoji(emojiId);
+        const appEmoji = await this.getApplicationEmoji(emojiId);
         if (appEmoji) return appEmoji.toString();
 
         return fallbackEmoji;
     }
 
-    public getApplicationEmoji(emojiId: string) {
+    public async getApplicationEmoji(emojiId: string) {
         if (!this.client.application) return undefined;
+        await this.ensureApplicationEmojis();
         return this.client.application.emojis.cache.get(emojiId);
     }
 
-    public getApplicationEmojiByName(emojiName: string) {
+    public async getApplicationEmojiByName(emojiName: string) {
         if (!this.client.application) return undefined;
+        await this.ensureApplicationEmojis();
         return this.client.application.emojis.cache.find(
             (emoji) => emoji.name === emojiName
         );

--- a/src/services/EmojiFallback.ts
+++ b/src/services/EmojiFallback.ts
@@ -9,6 +9,13 @@ export class EmojiFallback {
     constructor(client: Client, translator: TranslationManager) {
         this.client = client;
         this.translator = translator;
+        if (client.isReady()) {
+            client.application?.emojis?.fetch().catch(() => {});
+        } else {
+            client.once('ready', () => {
+                client.application?.emojis?.fetch().catch(() => {});
+            });
+        }
     }
 
     public getEmoji(


### PR DESCRIPTION
Los métodos del servicio `EmojiFallback` ahora también buscan en `client.application.emojis.cache` (emojis del Developer Portal de Discord) como fallback cuando no se encuentra el emoji en los gremios.

También se agregaron métodos directos:
- `getApplicationEmoji(emojiId)`
- `getApplicationEmojiByName(emojiName)`